### PR TITLE
Implement `GET /versions/:group/:hostname`

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -8,6 +8,7 @@ module Oxidized
   module Web
     class App < Sinatra::Base
       use Routes::Nodes
+      use Routes::Versions
     end
 
     class WebApp
@@ -37,4 +38,3 @@ module Oxidized
     end
   end
 end
-

--- a/lib/oxidized/web/app/models/versions.rb
+++ b/lib/oxidized/web/app/models/versions.rb
@@ -1,0 +1,40 @@
+require 'oxidized'
+module Oxidized
+  module Web
+    module Models
+      class Versions < Sinatra::Base
+        require 'time'
+        attr_accessor :versions
+        def initialize(node, group)
+          # This will probably change in the future.
+          # See supertylerc/oxidized-web#16.
+          group = nil if group == 'default'
+          @versions = settings.nodes.version node, group
+          normalize!
+        end
+
+        private
+
+        def normalize!
+          @versions.map! do |v|
+            v[:commit] = {
+              hash: v[:oid],
+              date: iso8601(v[:date]),
+              message: v[:message],
+              author: {
+                name: v[:author][:name],
+                email: v[:author][:email],
+                date: iso8601(v[:author][:time]),
+              }
+            }
+            v.select { |k, v| k == :commit }
+          end
+        end
+
+        def iso8601(t)
+          Time.parse(t.to_s).iso8601
+        end
+      end
+    end
+  end
+end

--- a/lib/oxidized/web/app/routes/versions.rb
+++ b/lib/oxidized/web/app/routes/versions.rb
@@ -1,0 +1,14 @@
+require 'json'
+
+module Oxidized
+  module Web
+    module Routes
+      class Versions < Sinatra::Base
+        get '/versions/:group/:hostname' do
+          @data = Models::Versions.new! params[:hostname], params[:group]
+          @data.versions.to_json
+        end
+      end
+    end
+  end
+end

--- a/raml/nodes.raml
+++ b/raml/nodes.raml
@@ -39,17 +39,17 @@ resourceTypes:
         example: json
         required: false
         enum: ['json']
-
-  /{hostname}:
-    type:
-      Member:
-        item: Node
-    get:
-      queryParameters:
-        format:
-          displayName: format
-          type: string
-          description: The format of the data for the API to return
-          example: json
-          required: false
-          enum: ['json']
+  /{group}:
+    /{hostname}:
+      type:
+        Member:
+          item: Node
+      get:
+        queryParameters:
+          format:
+            displayName: format
+            type: string
+            description: The format of the data for the API to return
+            example: json
+            required: false
+            enum: ['json']

--- a/raml/nodes.raml
+++ b/raml/nodes.raml
@@ -39,17 +39,17 @@ resourceTypes:
         example: json
         required: false
         enum: ['json']
-  /{group}:
-    /{hostname}:
-      type:
-        Member:
-          item: Node
-      get:
-        queryParameters:
-          format:
-            displayName: format
-            type: string
-            description: The format of the data for the API to return
-            example: json
-            required: false
-            enum: ['json']
+
+  /{hostname}:
+    type:
+      Member:
+        item: Node
+    get:
+      queryParameters:
+        format:
+          displayName: format
+          type: string
+          description: The format of the data for the API to return
+          example: json
+          required: false
+          enum: ['json']

--- a/raml/samples/version.json
+++ b/raml/samples/version.json
@@ -1,0 +1,12 @@
+{
+  "commit": {
+    "hash": "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
+    "date": "2016-01-02T20:06:13Z",
+    "author": {
+      "email": "oxidized@tylerc.me",
+      "name": "oxidized",
+      "date": "2016-01-02T20:06:13Z"
+    },
+    "message": "update 192.168.33.2"
+  }
+}

--- a/raml/schemas/version.json
+++ b/raml/schemas/version.json
@@ -1,0 +1,44 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://oxidized.example.com/schemas/version.json",
+  "properties": {
+    "commit": {
+      "type": "object",
+      "properties": {
+        "hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$",
+          "minLength": 40,
+          "maxLength": 40
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "author": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email"
+            },
+            "name": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "required": ["name", "date"]
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": ["author", "message", "hash", "date"]
+    }
+  },
+  "required": ["commit"]
+}

--- a/raml/versions.raml
+++ b/raml/versions.raml
@@ -11,6 +11,13 @@ types:
     example: !include samples/version.json
 
 resourceTypes:
+  Collection:
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              type: <<item>>[]
   Member:
     get:
       responses:
@@ -22,7 +29,7 @@ resourceTypes:
 /versions:
   /{hostname}:
     type:
-      Member:
+      Collection:
         item: Version
     get:
       queryParameters:

--- a/raml/versions.raml
+++ b/raml/versions.raml
@@ -1,0 +1,35 @@
+#%RAML 1.0
+---
+
+title: oxidized-web API
+baseUri: http://oxidized.example.com
+version: v1
+
+types:
+  Version:
+    schema: !include schemas/version.json
+    example: !include samples/version.json
+
+resourceTypes:
+  Member:
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              type: <<item>>
+
+/versions:
+  /{hostname}:
+    type:
+      Member:
+        item: Version
+    get:
+      queryParameters:
+        format:
+          displayName: format
+          type: string
+          description: The format of the data for the API to return
+          example: json
+          required: false
+          enum: ['json']

--- a/raml/versions.raml
+++ b/raml/versions.raml
@@ -27,16 +27,17 @@ resourceTypes:
               type: <<item>>
 
 /versions:
-  /{hostname}:
-    type:
-      Collection:
-        item: Version
-    get:
-      queryParameters:
-        format:
-          displayName: format
-          type: string
-          description: The format of the data for the API to return
-          example: json
-          required: false
-          enum: ['json']
+  /{group}:
+    /{hostname}:
+      type:
+        Collection:
+          item: Version
+      get:
+        queryParameters:
+          format:
+            displayName: format
+            type: string
+            description: The format of the data for the API to return
+            example: json
+            required: false
+            enum: ['json']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,19 @@ module RSpecMixin
         vars: {}
       }]
     end
+
+    def self.version(hostname, group)
+      [{
+        oid: "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
+        message: "update #{hostname}",
+        author: {
+           name: "oxidized",
+           time: "2016-01-02 20:06:13 UTC",
+           email: "oxidized@tylerc.me"
+        },
+        date: "2016-01-02 20:06:13 UTC"
+      }]
+    end
   end
   Sinatra::Base.set :nodes, TestNodes
 end

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path '../spec_helper.rb', __FILE__
 
 describe "Getting a version for a single node" do
   let(:expected) {
-    {
+    [{
       commit: {
         hash: "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
         date: "2016-01-02T20:06:13Z",
@@ -11,12 +11,12 @@ describe "Getting a version for a single node" do
           name: "oxidized",
           date: "2016-01-02T20:06:13Z"
         },
-        message: "update 192.168.33.2"
+        message: "update rtr1.example.com"
       }
-    }
+    }]
   }
   before do
-    get '/versions/rtr1.example.com'
+    get '/versions/default/rtr1.example.com'
   end
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
   it "should return a version for a node" do

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -1,0 +1,28 @@
+require File.expand_path '../spec_helper.rb', __FILE__
+
+describe "Getting a version for a single node" do
+  let(:expected) {
+    {
+      commit: {
+        hash: "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
+        date: "2016-01-02T20:06:13Z",
+        author: {
+          email: "oxidized@tylerc.me",
+          name: "oxidized",
+          date: "2016-01-02T20:06:13Z"
+        },
+        message: "update 192.168.33.2"
+      }
+    }
+  }
+  before do
+    get '/versions/rtr1.example.com'
+  end
+  let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
+  it "should return a version for a node" do
+    expect(response).to eq(expected)
+  end
+  it "should be successful" do
+    expect(last_response).to be_ok
+  end
+end


### PR DESCRIPTION
Closes #13.

Implements `GET /versions/:group/:hostname` using proposals from #13 as well as some of the original concepts from `oxidized-web`'s `GET /node/version?full_name=$GROUP/$HOSTNAME`.

Adds an API definition (`raml/versions.raml`), response schema (`raml/schemas/version.json`), and response sample (`raml/samples/version.json`).

Adds a new route class (`lib/oxidized/web/app/routes/versions.rb`) and new model (`lib/oxidized/web/app/models/versions.rb`).

Adds tests and helpers (`spec/spec_helper.rb` and `spec/versions_spec.rb`).