### PR TITLE
Get Latest Version

### DIFF
--- a/lib/oxidized/web/app/routes/versions.rb
+++ b/lib/oxidized/web/app/routes/versions.rb
@@ -8,6 +8,11 @@ module Oxidized
           @data = Models::Versions.new! params[:hostname], params[:group]
           @data.versions.to_json
         end
+
+        get '/versions/:group/:hostname/latest' do
+          @data = Models::Versions.new! params[:hostname], params[:group]
+          @data.versions.last.to_json
+        end
       end
     end
   end

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -26,3 +26,33 @@ describe 'Getting a version for a single node' do
     expect(last_response).to be_ok
   end
 end
+
+describe 'Getting the latest version for a node' do
+  let(:expected) do
+    {
+      commit: {
+        hash: '9e890265f00a7369e25e7ef2de92e5f94a65a0ab',
+        date: '2016-01-02T20:06:13Z',
+        author: {
+          email: 'oxidized@tylerc.me',
+          name: 'oxidized',
+          date: '2016-01-02T20:06:13Z'
+        },
+        message: 'update rtr1.example.com'
+      }
+    }
+  end
+
+  before do
+    get '/versions/default/rtr1.example.com/latest'
+  end
+
+  let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
+  it 'should return the latest version for a node' do
+    expect(response).to eq(expected)
+  end
+
+  it 'should be successful' do
+    expect(last_response).to be_ok
+  end
+end


### PR DESCRIPTION
Closes #17.

Adds a route to get the latest version for a node: `/versions/:group/:hostname/latest`.
Adds tests to validate the response for the new route.