### PR TITLE
Get /versions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,8 @@ engines:
       languages:
         - ruby
         - javascript
+    exclude_fingerprints:
+      - efbc648172f3fa9a34e3da2937ee2fb8
   fixme:
     enabled: true
   eslint:
@@ -19,6 +21,7 @@ engines:
     exclude_fingerprints:
       - cbee5412ef89b2509bfc04c790d1f50f
       - 1e76411a6b5ac5f855d9d7aa437d82ad
+      - abbb6927aa366917180792edd397d0a5
   scss-lint:
     enabled: true
 

--- a/lib/oxidized/web/app/routes/versions.rb
+++ b/lib/oxidized/web/app/routes/versions.rb
@@ -5,13 +5,17 @@ module Oxidized
     module Routes
       class Versions < Sinatra::Base
         get '/versions/:group/:hostname' do
-          @data = Models::Versions.new! params[:hostname], params[:group]
-          @data.versions.to_json
+          Models::Versions.new!.find(params[:group], params[:hostname]).to_json
         end
 
         get '/versions/:group/:hostname/latest' do
-          @data = Models::Versions.new! params[:hostname], params[:group]
-          @data.versions.last.to_json
+          @data = Models::Versions.new!.find(params[:group], params[:hostname])
+          @data.last.to_json
+        end
+
+        get '/versions' do
+          @data = Models::Versions.new!
+          @data.versions.to_json
         end
       end
     end

--- a/raml/samples/versions.json
+++ b/raml/samples/versions.json
@@ -1,0 +1,14 @@
+{
+  "rtr1.example.com": {
+    "commit": {
+      "hash": "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
+      "date": "2016-01-02T20:06:13Z",
+      "author": {
+        "email": "oxidized@tylerc.me",
+        "name": "oxidized",
+        "date": "2016-01-02T20:06:13Z"
+      },
+      "message": "update 192.168.33.2"
+    }
+  }
+}

--- a/raml/samples/versions.json
+++ b/raml/samples/versions.json
@@ -1,14 +1,16 @@
 {
-  "rtr1.example.com": {
-    "commit": {
-      "hash": "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
-      "date": "2016-01-02T20:06:13Z",
-      "author": {
-        "email": "oxidized@tylerc.me",
-        "name": "oxidized",
-        "date": "2016-01-02T20:06:13Z"
-      },
-      "message": "update 192.168.33.2"
+  "default": {
+    "rtr1.example.com": {
+      "commit": {
+        "hash": "9e890265f00a7369e25e7ef2de92e5f94a65a0ab",
+        "date": "2016-01-02T20:06:13Z",
+        "author": {
+          "email": "oxidized@tylerc.me",
+          "name": "oxidized",
+          "date": "2016-01-02T20:06:13Z"
+        },
+        "message": "update 192.168.33.2"
+      }
     }
   }
 }

--- a/raml/schemas/versions.json
+++ b/raml/schemas/versions.json
@@ -3,10 +3,15 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "http://oxidized.example.com/schemas/version.json",
   "properties": {
-    "hostname": {
-      "type": "array",
-      "items": {
-        "$ref": "version.json#/properties"
+    "group": {
+      "type": "object",
+      "properties": {
+        "hostname": {
+          "type": "array",
+          "items": {
+            "$ref": "version.json#/properties"
+          }
+        }
       }
     }
   }

--- a/raml/schemas/versions.json
+++ b/raml/schemas/versions.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://oxidized.example.com/schemas/version.json",
+  "properties": {
+    "hostname": {
+      "type": "array",
+      "items": {
+        "$ref": "version.json#/properties"
+      }
+    }
+  }
+}

--- a/raml/versions.raml
+++ b/raml/versions.raml
@@ -9,6 +9,9 @@ types:
   Version:
     schema: !include schemas/version.json
     example: !include samples/version.json
+  Versions:
+    schema: !include schemas/versions.json
+    example: !include samples/versions.json
 
 resourceTypes:
   Collection:
@@ -27,6 +30,13 @@ resourceTypes:
               type: <<item>>
 
 /versions:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: Versions
+
   /{group}:
     /{hostname}:
       type:

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -56,3 +56,35 @@ describe 'Getting the latest version for a node' do
     expect(last_response).to be_ok
   end
 end
+
+describe 'Getting a list of versions for all nodes' do
+  let(:expected) do
+    {
+      :'rtr1.example.com' => [{
+        commit: {
+          hash: '9e890265f00a7369e25e7ef2de92e5f94a65a0ab',
+          date: '2016-01-02T20:06:13Z',
+          author: {
+            email: 'oxidized@tylerc.me',
+            name: 'oxidized',
+            date: '2016-01-02T20:06:13Z'
+          },
+          message: 'update rtr1.example.com'
+        }
+      }]
+    }
+  end
+
+  before do
+    get '/versions'
+  end
+
+  let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
+  it 'should return a list of versions for all nodes' do
+    expect(response).to eq(expected)
+  end
+
+  it 'should be successful' do
+    expect(last_response).to be_ok
+  end
+end

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -60,18 +60,20 @@ end
 describe 'Getting a list of versions for all nodes' do
   let(:expected) do
     {
-      :'rtr1.example.com' => [{
-        commit: {
-          hash: '9e890265f00a7369e25e7ef2de92e5f94a65a0ab',
-          date: '2016-01-02T20:06:13Z',
-          author: {
-            email: 'oxidized@tylerc.me',
-            name: 'oxidized',
-            date: '2016-01-02T20:06:13Z'
-          },
-          message: 'update rtr1.example.com'
-        }
-      }]
+      default: {
+        :'rtr1.example.com' => [{
+          commit: {
+            hash: '9e890265f00a7369e25e7ef2de92e5f94a65a0ab',
+            date: '2016-01-02T20:06:13Z',
+            author: {
+              email: 'oxidized@tylerc.me',
+              name: 'oxidized',
+              date: '2016-01-02T20:06:13Z'
+            },
+            message: 'update rtr1.example.com'
+          }
+        }]
+      }
     }
   end
 


### PR DESCRIPTION
Closes #16.

Adds tests for `/versions` route.
Adds API RAML specification for `/versions` route.
Updates the model to allow for the `/versions` route by using new `Versions#find` method for single hosts, changing `Versions#normalize!` to `Versions#normalize` so it can operate on the structure instead of modifying it in place.