### PR TITLE
Add RAML specification for latest version

### DIFF
--- a/raml/versions.raml
+++ b/raml/versions.raml
@@ -51,3 +51,8 @@ resourceTypes:
             example: json
             required: false
             enum: ['json']
+      /latest:
+        type:
+          Collection:
+            item:
+              Version


### PR DESCRIPTION
Closes #33.

Adds a missing RAML specification for /versions/:group/:hostname/latest
See supertylerc/oxidized-web#33