### PR TITLE
Add Authentication

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,7 +20,8 @@ engines:
       Rubocop/Style/TrailingBlankLines:
         enabled: false
       Rubocop/Style/GlobalVars:
-        AllowedVariables: ['CLIENT_ID', 'CLIENT_SECRET']
+        enabled: true
+        AllowedVariables: [$CLIENT_ID, $CLIENT_SECRET]
     exclude_fingerprints:
       - cbee5412ef89b2509bfc04c790d1f50f
       - 1e76411a6b5ac5f855d9d7aa437d82ad

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,6 +26,8 @@ engines:
       - cbee5412ef89b2509bfc04c790d1f50f
       - 1e76411a6b5ac5f855d9d7aa437d82ad
       - abbb6927aa366917180792edd397d0a5
+      - dfd42f4ec9538db9b23a1c559f9b2460
+      - 7c95a732db38d968252218dc25196c81
   scss-lint:
     enabled: true
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,8 @@ engines:
     checks:
       Rubocop/Style/TrailingBlankLines:
         enabled: false
+      Rubocop/Style/GlobalVars:
+        AllowedVariables: ['CLIENT_ID', 'CLIENT_SECRET']
     exclude_fingerprints:
       - cbee5412ef89b2509bfc04c790d1f50f
       - 1e76411a6b5ac5f855d9d7aa437d82ad

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,6 +28,10 @@ engines:
       - abbb6927aa366917180792edd397d0a5
       - dfd42f4ec9538db9b23a1c559f9b2460
       - 7c95a732db38d968252218dc25196c81
+      - 3cfbf36e361979a17b130e445f86a81a
+      - e957c77eace17b2a7b5b5cd680cc268e
+      - e034839a5df93ca344a72ac8ac83b0d9
+      - c866fedf1f24f51db531d05f1daa6244
   scss-lint:
     enabled: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 .env
 coverage
 gems/
+*.db

--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -1,5 +1,7 @@
 require 'sinatra/base'
-
+require 'sinatra/sequel'
+Dir["#{File.dirname(__FILE__)}/web/app/migrations/*.rb"].each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/web/app/helpers/*.rb"].each { |file| require file }
 Dir["#{File.dirname(__FILE__)}/web/app/routes/*.rb"].each { |file| require file }
 Dir["#{File.dirname(__FILE__)}/web/app/models/*.rb"].each { |file| require file }
 $LOAD_PATH << File.expand_path('../', __FILE__)
@@ -7,6 +9,12 @@ $LOAD_PATH << File.expand_path('../', __FILE__)
 module Oxidized
   module Web
     class App < Sinatra::Base
+      helpers Helpers
+
+      before do
+        valid_key?
+      end
+
       not_found do
         {
           error: 'Not Found Exception',

--- a/lib/oxidized/web/app/helpers/auth.rb
+++ b/lib/oxidized/web/app/helpers/auth.rb
@@ -4,18 +4,21 @@ module Oxidized
   module Web
     module Helpers
       def valid_key?
-        halt 403 unless env['HTTP_AUTHORIZATION']
-        auth_header = env['HTTP_AUTHORIZATION'].split(':')
-        client_id = auth_header[0]
-        signature = auth_header[1]
-        client = Models::Users.first(client_id: client_id)
+        client = Models::Users.first(client_id: auth_header[:client_id])
         halt 403 if client.nil?
-        data = request.path
-        error 401 unless sign(client[:client_secret], data) == signature
+        error 401 unless sign(client[:client_secret], request.path) == auth_header[:signature]
       end
 
       def sign(client_secret, data)
         OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), client_secret, data)
+      end
+
+      private
+
+      def auth_header
+        halt 403 unless env['HTTP_AUTHORIZATION']
+        auth_header = env['HTTP_AUTHORIZATION'].split(':')
+        { client_id: auth_header[0], signature: auth_header[1] }
       end
     end
   end

--- a/lib/oxidized/web/app/helpers/auth.rb
+++ b/lib/oxidized/web/app/helpers/auth.rb
@@ -1,0 +1,22 @@
+require 'oxidized'
+require 'openssl'
+module Oxidized
+  module Web
+    module Helpers
+      def valid_key?
+        halt 403 unless env['HTTP_AUTHORIZATION']
+        auth_header = env['HTTP_AUTHORIZATION'].split(':')
+        client_id = auth_header[0]
+        signature = auth_header[1]
+        client = Models::Users.first(client_id: client_id)
+        halt 403 if client.nil?
+        data = request.path
+        error 401 unless sign(client[:client_secret], data) == signature
+      end
+
+      def sign(client_secret, data)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), client_secret, data)
+      end
+    end
+  end
+end

--- a/lib/oxidized/web/app/helpers/auth.rb
+++ b/lib/oxidized/web/app/helpers/auth.rb
@@ -2,7 +2,7 @@ require 'oxidized'
 require 'openssl'
 module Oxidized
   module Web
-    module Helpers
+    module Helpers #:nodoc:
       def valid_key?
         client = Models::Users.first(client_id: auth_header[:client_id])
         halt 403 if client.nil?

--- a/lib/oxidized/web/app/migrations/2016_01_30_215232.rb
+++ b/lib/oxidized/web/app/migrations/2016_01_30_215232.rb
@@ -1,0 +1,14 @@
+require 'sinatra'
+migration "Create Users Database" do
+  database.create_table :users do
+    primary_key :id
+    text :first_name
+    text :last_name
+    text :client_id
+    text :client_secret
+    integer :privilege_level, null: false
+    timestamp :created_at, null: false
+
+    index :client_id, unique: true
+  end
+end

--- a/lib/oxidized/web/app/migrations/2016_01_30_215232.rb
+++ b/lib/oxidized/web/app/migrations/2016_01_30_215232.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-migration "Create Users Database" do
+migration 'Create Users Database' do
   database.create_table :users do
     primary_key :id
     text :first_name

--- a/lib/oxidized/web/app/models/users.rb
+++ b/lib/oxidized/web/app/models/users.rb
@@ -1,0 +1,8 @@
+module Oxidized
+  module Web
+    module Models
+      class Users < Sequel::Model
+      end
+    end
+  end
+end

--- a/lib/oxidized/web/app/routes/nodes.rb
+++ b/lib/oxidized/web/app/routes/nodes.rb
@@ -4,6 +4,11 @@ module Oxidized
   module Web
     module Routes
       class Nodes < Sinatra::Base
+        helpers Helpers
+        before do
+          valid_key?
+        end
+
         get '/nodes' do
           @data = Models::Nodes.new!
           @data.nodes.to_json

--- a/lib/oxidized/web/app/routes/versions.rb
+++ b/lib/oxidized/web/app/routes/versions.rb
@@ -4,6 +4,11 @@ module Oxidized
   module Web
     module Routes
       class Versions < Sinatra::Base
+        helpers Helpers
+        before do
+          valid_key?
+        end
+
         get '/versions/:group/:hostname' do
           Models::Versions.new!.find(params[:group], params[:hostname]).to_json
         end

--- a/oxidized-web.gemspec
+++ b/oxidized-web.gemspec
@@ -21,4 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'haml',                '~> 4.0'
   s.add_runtime_dependency 'sass',                '~> 3.4'
   s.add_runtime_dependency 'emk-sinatra-url-for', '~> 0.2'
+  s.add_runtime_dependency 'sequel',              '~> 4.30'
+  s.add_runtime_dependency 'sinatra-sequel',      '~> 0.9'
+  s.add_runtime_dependency 'sqlite3',             '~> 1.3'
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -12,7 +12,9 @@ describe 'Getting an invalid URI' do
     }
   end
   before do
-    get '/hodor'
+    route = '/hodor'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
   it 'should return a custom 404 error' do
@@ -25,5 +27,36 @@ describe 'Getting an invalid URI' do
 
   it 'should return an HTTP 404 code' do
     expect(last_response.status).to eq(404)
+  end
+end
+
+describe 'Sending an invalid HMAC' do
+  before do
+    route = '/nodes'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign('hodor', route)}"
+    get route
+  end
+
+  it 'should fail' do
+    expect(last_response).to_not be_ok
+  end
+
+  it 'should return an HTTP 401 code' do
+    expect(last_response.status).to eq(401)
+  end
+end
+
+describe 'Omitting the AUTHORIZATION header' do
+  before do
+    route = '/nodes'
+    get route
+  end
+
+  it 'should fail' do
+    expect(last_response).to_not be_ok
+  end
+
+  it 'should return an HTTP 403 code' do
+    expect(last_response.status).to eq(403)
   end
 end

--- a/spec/nodes_spec.rb
+++ b/spec/nodes_spec.rb
@@ -16,7 +16,9 @@ describe 'Getting a list of nodes' do
     }]
   end
   before do
-    get '/nodes'
+    route = '/nodes'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
   it 'should return a list of nodes' do
@@ -43,7 +45,9 @@ describe 'Getting a single node' do
     }
   end
   before do
-    get '/nodes/rtr1.example.com'
+    route = '/nodes/rtr1.example.com'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
   it 'should return a list of nodes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,18 @@ module RSpecMixin
     Oxidized::Web::App
   end
 
+  def create_user(id, secret)
+    Oxidized::Web::Models::Users.new do |u|
+      u.first_name = 'Oxidized'
+      u.last_name = 'Web'
+      u.client_id = id
+      u.client_secret = secret
+      u.privilege_level = 15
+      u.created_at = current_time
+      u.save
+    end
+  end
+
   class TestNodes
     def self.list
       [{

--- a/spec/users_spec.rb
+++ b/spec/users_spec.rb
@@ -1,0 +1,78 @@
+require File.expand_path '../spec_helper.rb', __FILE__
+
+describe 'Creating a new user' do
+  let(:current_time) { Time.now.to_s }
+  it 'creates a new user' do
+    Oxidized::Web::Models::Users.new do |u|
+      u.first_name = 'Oxidized'
+      u.last_name = 'Web'
+      u.client_id = 'random'
+      u.client_secret = 'number'
+      u.privilege_level = 15
+      u.created_at = current_time
+      u.save
+    end
+  end
+
+  let(:user) { Oxidized::Web::Models::Users.first(client_id: 'random') }
+
+  it 'has the correct attributes' do
+    expect(user[:first_name]).to eq('Oxidized')
+    expect(user[:last_name]).to eq('Web')
+    expect(user[:client_id]).to eq('random')
+    expect(user[:client_secret]).to eq('number')
+    expect(user[:privilege_level]).to eq(15)
+    expect(user[:created_at].to_s).to eq(current_time)
+  end
+
+  it 'cannot create the same client id' do
+    expect {
+      Oxidized::Web::Models::Users.new do |u|
+        u.first_name = 'Hodor'
+        u.last_name = 'the Great'
+        u.client_id = 'random'
+        u.client_secret = 'supersecret'
+        u.privilege_level = 7
+        u.created_at = current_time
+        u.save
+      end
+    }.to raise_exception(Sequel::UniqueConstraintViolation)
+  end
+
+  it 'can create multiple client ids for the same person' do
+    Oxidized::Web::Models::Users.new do |u|
+      u.first_name = 'Oxidized'
+      u.last_name = 'Web'
+      u.client_id = 'hodor'
+      u.client_secret = 'number'
+      u.privilege_level = 15
+      u.created_at = current_time
+      u.save
+    end
+  end
+
+  after :all do
+    Oxidized::Web::Models::Users.filter(client_id: 'random').delete
+    Oxidized::Web::Models::Users.filter(client_id: 'hodor').delete
+  end
+end
+
+describe 'Deleting a new user' do
+  let(:current_time) { Time.now.to_s }
+  before do
+    Oxidized::Web::Models::Users.new do |u|
+      u.first_name = 'Oxidized'
+      u.last_name = 'Web'
+      u.client_id = 'random'
+      u.client_secret = 'number'
+      u.privilege_level = 15
+      u.created_at = current_time
+      u.save
+    end
+  end
+
+  it 'deletes a user' do
+    Oxidized::Web::Models::Users.filter(client_id: 'random').delete
+    expect(Oxidized::Web::Models::Users.filter(client_id: 'random')).to be_empty
+  end
+end

--- a/spec/users_spec.rb
+++ b/spec/users_spec.rb
@@ -3,15 +3,7 @@ require File.expand_path '../spec_helper.rb', __FILE__
 describe 'Creating a new user' do
   let(:current_time) { Time.now.to_s }
   it 'creates a new user' do
-    Oxidized::Web::Models::Users.new do |u|
-      u.first_name = 'Oxidized'
-      u.last_name = 'Web'
-      u.client_id = 'random'
-      u.client_secret = 'number'
-      u.privilege_level = 15
-      u.created_at = current_time
-      u.save
-    end
+    create_user 'random', 'number'
   end
 
   let(:user) { Oxidized::Web::Models::Users.first(client_id: 'random') }
@@ -26,29 +18,13 @@ describe 'Creating a new user' do
   end
 
   it 'cannot create the same client id' do
-    expect {
-      Oxidized::Web::Models::Users.new do |u|
-        u.first_name = 'Hodor'
-        u.last_name = 'the Great'
-        u.client_id = 'random'
-        u.client_secret = 'supersecret'
-        u.privilege_level = 7
-        u.created_at = current_time
-        u.save
-      end
-    }.to raise_exception(Sequel::UniqueConstraintViolation)
+    expect do
+      create_user 'random', 'supersecret'
+    end.to raise_exception(Sequel::UniqueConstraintViolation)
   end
 
   it 'can create multiple client ids for the same person' do
-    Oxidized::Web::Models::Users.new do |u|
-      u.first_name = 'Oxidized'
-      u.last_name = 'Web'
-      u.client_id = 'hodor'
-      u.client_secret = 'number'
-      u.privilege_level = 15
-      u.created_at = current_time
-      u.save
-    end
+    create_user 'hodor', 'number'
   end
 
   after :all do
@@ -60,15 +36,7 @@ end
 describe 'Deleting a new user' do
   let(:current_time) { Time.now.to_s }
   before do
-    Oxidized::Web::Models::Users.new do |u|
-      u.first_name = 'Oxidized'
-      u.last_name = 'Web'
-      u.client_id = 'random'
-      u.client_secret = 'number'
-      u.privilege_level = 15
-      u.created_at = current_time
-      u.save
-    end
+    create_user 'random', 'number'
   end
 
   it 'deletes a user' do

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -16,7 +16,9 @@ describe 'Getting a version for a single node' do
     }]
   end
   before do
-    get '/versions/default/rtr1.example.com'
+    route = '/versions/default/rtr1.example.com'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
   it 'should return a version for a node' do
@@ -44,7 +46,9 @@ describe 'Getting the latest version for a node' do
   end
 
   before do
-    get '/versions/default/rtr1.example.com/latest'
+    route = '/versions/default/rtr1.example.com/latest'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
 
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }
@@ -78,7 +82,9 @@ describe 'Getting a list of versions for all nodes' do
   end
 
   before do
-    get '/versions'
+    route = '/versions'
+    header 'AUTHORIZATION', "#{$CLIENT_ID}:#{sign($CLIENT_SECRET, route)}"
+    get route
   end
 
   let(:response) { JSON.parse(last_response.body, symbolize_names: true) }


### PR DESCRIPTION
Closes #35.

Adds `sequel` and `sinatra-sequel` to manage users and tokens.
Adds a model for users.
Requires all routes to be authenticated prior to processing.
Updates testing.
Introduces the first database migration.